### PR TITLE
feat(generator-web): deterministic CSS class name minification

### DIFF
--- a/generator/web-cli/README.md
+++ b/generator/web-cli/README.md
@@ -6,7 +6,8 @@ Refer to the [generator-common-cli README](../common-cli/README.md) for command-
 
 ## Properties
 
-* `me.kcra.takenaka.generator.web.env` (`development` (default/fallback) or `production`) - The generator environment, `production` minifies all files to decrease file size.
+* `me.kcra.takenaka.generator.web.minify` (boolean, defaults to `true`) - Whether all files should be minified to decrease file size.
+* `me.kcra.takenaka.generator.web.minify.deterministic` (boolean, defaults to `true`) - Whether the output of the minifier should be consistent across runs (useful for diffing the output, but increases file size).
 * `me.kcra.takenaka.generator.web.concurrencyLimit` (integer, defaults to `-1` [no limit]) - The parallelism limit for the coroutine dispatcher, an appropriate value is chosen by default.
 * `me.kcra.takenaka.generator.web.index.foreign` (a complex expression) - Javadoc sites to be linked to in the generated output.
   * the value is a comma-separated (no space after the comma) list of strings, and the string can be:

--- a/generator/web-cli/src/main/kotlin/me/kcra/takenaka/generator/web/cli/WebCLI.kt
+++ b/generator/web-cli/src/main/kotlin/me/kcra/takenaka/generator/web/cli/WebCLI.kt
@@ -29,7 +29,7 @@ import me.kcra.takenaka.core.mapping.resolve.*
 import me.kcra.takenaka.core.util.objectMapper
 import me.kcra.takenaka.generator.common.cli.CLI
 import me.kcra.takenaka.generator.web.*
-import me.kcra.takenaka.generator.web.transformers.Minifier
+import me.kcra.takenaka.generator.web.transformers.DeterministicMinifier
 import me.kcra.takenaka.generator.web.transformers.Transformer
 import mu.KotlinLogging
 
@@ -54,7 +54,7 @@ class WebCLI : CLI {
 
         val transformers = mutableListOf<Transformer>()
         if (isProduction) {
-            transformers += Minifier()
+            transformers += DeterministicMinifier()
         }
 
         val concurrencyLimit = System.getProperty("me.kcra.takenaka.generator.web.concurrencyLimit", "-1").toInt()

--- a/generator/web-cli/src/main/kotlin/me/kcra/takenaka/generator/web/cli/WebCLI.kt
+++ b/generator/web-cli/src/main/kotlin/me/kcra/takenaka/generator/web/cli/WebCLI.kt
@@ -30,6 +30,7 @@ import me.kcra.takenaka.core.util.objectMapper
 import me.kcra.takenaka.generator.common.cli.CLI
 import me.kcra.takenaka.generator.web.*
 import me.kcra.takenaka.generator.web.transformers.DeterministicMinifier
+import me.kcra.takenaka.generator.web.transformers.Minifier
 import me.kcra.takenaka.generator.web.transformers.Transformer
 import mu.KotlinLogging
 
@@ -49,12 +50,16 @@ class WebCLI : CLI {
      * @param mappingWorkspace the workspace where the generator can cache mappings
      */
     override fun generate(output: Workspace, versions: List<String>, mappingWorkspace: CompositeWorkspace) {
-        val isProduction = System.getProperty("me.kcra.takenaka.generator.web.env", "development").lowercase() == "production"
-        logger.info { "Building in ${if (isProduction) "production" else "development"} mode" }
-
         val transformers = mutableListOf<Transformer>()
-        if (isProduction) {
-            transformers += DeterministicMinifier()
+
+        val minify = System.getProperty("me.kcra.takenaka.generator.web.minify", "true").toBoolean()
+        if (minify) {
+            val deterministic = System.getProperty("me.kcra.takenaka.generator.web.minify.deterministic", "true").toBoolean()
+            if (deterministic) {
+                transformers += DeterministicMinifier()
+            } else {
+                transformers += Minifier()
+            }
         }
 
         val concurrencyLimit = System.getProperty("me.kcra.takenaka.generator.web.concurrencyLimit", "-1").toInt()

--- a/generator/web/src/main/kotlin/me/kcra/takenaka/generator/web/WebGenerator.kt
+++ b/generator/web/src/main/kotlin/me/kcra/takenaka/generator/web/WebGenerator.kt
@@ -31,6 +31,7 @@ import me.kcra.takenaka.generator.common.ContributorProvider
 import me.kcra.takenaka.generator.web.components.footerComponent
 import me.kcra.takenaka.generator.web.components.navComponent
 import me.kcra.takenaka.generator.web.pages.*
+import me.kcra.takenaka.generator.web.transformers.Minifier
 import me.kcra.takenaka.generator.web.transformers.Transformer
 import net.fabricmc.mappingio.tree.MappingTree
 import org.w3c.dom.Document
@@ -74,6 +75,7 @@ class WebGenerator(
     val spigotLikeNamespaces: List<String> = emptyList()
 ) : AbstractGenerator(workspace, versions, coroutineDispatcher, skipSynthetics, mappingWorkspace, contributorProvider) {
     private val namespaceFriendlyNames = namespaces.mapValues { it.value.friendlyName }
+    private val hasMinifier = transformers.any { it is Minifier }
 
     /**
      * Launches the generator.
@@ -246,9 +248,9 @@ class WebGenerator(
         file.parent.createDirectories()
 
         if (transformers.isEmpty()) {
-            file.writer().use { it.write(this, prettyPrint = false) }
+            file.writer().use { it.write(this) }
         } else {
-            file.writeText(serialize(prettyPrint = false).transformHtml())
+            file.writeText(serialize(prettyPrint = !hasMinifier).transformHtml())
         }
     }
 

--- a/generator/web/src/main/kotlin/me/kcra/takenaka/generator/web/transformers/DeterministicMinifier.kt
+++ b/generator/web/src/main/kotlin/me/kcra/takenaka/generator/web/transformers/DeterministicMinifier.kt
@@ -1,0 +1,43 @@
+/*
+ * This file is part of takenaka, licensed under the Apache License, Version 2.0 (the "License").
+ *
+ * Copyright (c) 2023 Matous Kucera
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.kcra.takenaka.generator.web.transformers
+
+import kotlin.concurrent.withLock
+import kotlin.math.abs
+
+/**
+ * A transformer that minifies web resources in a deterministic way.
+ *
+ * @author Matouš Kučera
+ */
+class DeterministicMinifier : Minifier() {
+    /**
+     * Minifies raw HTML markup.
+     *
+     * @param content the raw HTML markup
+     * @return the transformed markup
+     */
+    override fun transformHtml(content: String): String = lock.withLock {
+        content.replace(CLASS_ATTR_REGEX) { m ->
+            """class="${m.groups[1]?.value?.split(' ')?.joinToString(" ") { klass ->
+                // minify class names based on their hash code, shortened to Short.MAX_VALUE
+                classes.computeIfAbsent(klass) { k -> minifiedClass(abs(k.hashCode().toShort().toInt())) }
+            } ?: ""}""""
+        }
+    }
+}


### PR DESCRIPTION
This aims to make CSS class name generation more deterministic, i.e. if you run the generator multiple times, it will generate the same minified CSS class names, at expense of increasing file size slightly.

Currently a lot of the generation is parallelized, thus the CSS class names arrive at the minifier as they are processed.
This isn't a problem, but results in most class names changing each time the generator is ran, which makes versioning the output via Git (or a similar VCS) worse (large diffs).

This implementation uses the `String#hashCode` method to generate "unique" names (there is a possibility for conflicts, but in the context of the little CSS classes we have, it shouldn't be a problem).