### PR TITLE
feat(generator-web): Default modifier for interface methods and enum constant summary

### DIFF
--- a/core/src/main/kotlin/me/kcra/takenaka/core/mapping/util/mappings.kt
+++ b/core/src/main/kotlin/me/kcra/takenaka/core/mapping/util/mappings.kt
@@ -20,8 +20,6 @@ package me.kcra.takenaka.core.mapping.util
 import me.kcra.takenaka.core.util.md5Digest
 import me.kcra.takenaka.core.util.updateAndHex
 import net.fabricmc.mappingio.tree.MappingTreeView
-import org.objectweb.asm.Opcodes
-import java.lang.reflect.Modifier
 
 /**
  * Returns IDs of all namespaces in this tree.
@@ -55,42 +53,3 @@ val MappingTreeView.ElementMappingView.hash: String
             .sorted()
             .joinToString(",")
     )
-
-/**
- * Formats a modifier integer into a string.
- *
- * @param mask the modifier mask (you can get that from the [Modifier] class)
- * @return the modifier string, **may end with a space**
- */
-fun Int.formatModifiers(mask: Int = 0, interfaceMethod: Boolean = false): String = buildString {
-    val mMod = this@formatModifiers and mask
-
-    // remove public and abstract modifiers on interface methods, implicit in some cases
-    // see: https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.4
-    if (!interfaceMethod && (mMod and Opcodes.ACC_PUBLIC) != 0) append("public ")
-    if ((mMod and Opcodes.ACC_PRIVATE) != 0) append("private ")
-    if ((mMod and Opcodes.ACC_PROTECTED) != 0) append("protected ")
-    if ((mMod and Opcodes.ACC_STATIC) != 0) append("static ")
-
-    if (interfaceMethod && (mMod and Opcodes.ACC_ABSTRACT) == 0 && (mMod and Opcodes.ACC_STATIC) == 0) {
-        append("default ")
-    }
-    // enums can have an abstract modifier (methods included) if its constants have a custom impl
-    // TODO: should we remove that?
-
-    // an interface is implicitly abstract
-    // we need to check the unmasked modifiers here, since ACC_INTERFACE is not among Modifier#classModifiers
-    if ((mMod and Opcodes.ACC_ABSTRACT) != 0 && (this@formatModifiers and Opcodes.ACC_INTERFACE) == 0 && !interfaceMethod) append("abstract ")
-    if ((mMod and Opcodes.ACC_FINAL) != 0) {
-        // enums and records are implicitly final
-        // we need to check the unmasked modifiers here, since ACC_ENUM is not among Modifier#classModifiers
-        if (mask != Modifier.classModifiers() || ((this@formatModifiers and Opcodes.ACC_ENUM) == 0 && (this@formatModifiers and Opcodes.ACC_RECORD) == 0)) {
-            append("final ")
-        }
-    }
-    if ((mMod and Opcodes.ACC_NATIVE) != 0) append("native ")
-    if ((mMod and Opcodes.ACC_STRICT) != 0) append("strict ")
-    if ((mMod and Opcodes.ACC_SYNCHRONIZED) != 0) append("synchronized ")
-    if ((mMod and Opcodes.ACC_TRANSIENT) != 0) append("transient ")
-    if ((mMod and Opcodes.ACC_VOLATILE) != 0) append("volatile ")
-}

--- a/generator/web/src/main/kotlin/me/kcra/takenaka/generator/web/pages/classPage.kt
+++ b/generator/web/src/main/kotlin/me/kcra/takenaka/generator/web/pages/classPage.kt
@@ -34,7 +34,6 @@ import me.kcra.takenaka.core.mapping.resolve.impl.signature
 import me.kcra.takenaka.core.mapping.resolve.impl.superClass
 import me.kcra.takenaka.core.mapping.toInternalName
 import me.kcra.takenaka.core.mapping.util.allNamespaceIds
-import me.kcra.takenaka.core.mapping.util.formatModifiers
 import me.kcra.takenaka.generator.web.*
 import me.kcra.takenaka.generator.web.components.*
 import net.fabricmc.mappingio.tree.MappingTreeView
@@ -64,6 +63,7 @@ fun GenerationContext.classPage(klass: MappingTreeView.ClassMappingView, hash: S
         getClassRelativePath(klassName, name)
     }
     val klassDeclaration = klass.formatDescriptor(friendlyKlassName, remapper)
+    val klassType = classTypeOf(klass.modifiers)
     head {
         versionRootComponent(rootPath = versionRootPath)
         defaultResourcesComponent(rootPath)
@@ -167,46 +167,38 @@ fun GenerationContext.classPage(klass: MappingTreeView.ClassMappingView, hash: S
                     fieldMask = fieldMask and Modifier.PUBLIC.inv() and Modifier.STATIC.inv() and Modifier.FINAL.inv()
                 }
 
-                var fields = klass.fields
+                val (enumFields, fields) = klass.fields.partition { (it.modifiers and Opcodes.ACC_ENUM) != 0 }
 
-                if (classTypeOf(klassDeclaration.modifiers) == ClassType.ENUM) {
-                    val enumModifier = Modifier.PUBLIC or Modifier.STATIC or Modifier.FINAL or Opcodes.ACC_ENUM
-
-                    val (enumFields, nonEnumFields) = fields.partition { (it.modifiers and enumModifier) == enumModifier && it.srcDesc == 'L' + klass.srcName + ';' }
-
-                    if (enumFields.isNotEmpty()) {
-                        fields = nonEnumFields
-
-                        addContentSpacer()
-                        h4 {
-                            +"Enum constant summary"
-                        }
-                        table(classes = "styled-table styled-mobile-table") {
-                            thead {
-                                tr {
-                                    th {
-                                        +"Enum Constant"
-                                    }
+                if (enumFields.isNotEmpty()) {
+                    addContentSpacer()
+                    h4 {
+                        +"Enum constant summary"
+                    }
+                    table(classes = "styled-table styled-mobile-table") {
+                        thead {
+                            tr {
+                                th {
+                                    +"Enum Constant"
                                 }
                             }
-                            tbody {
-                                enumFields.forEach { field ->
-                                    tr {
-                                        td {
-                                            table {
-                                                tbody {
-                                                    klass.tree.allNamespaceIds.forEach { id ->
-                                                        val ns = klass.tree.getNamespaceName(id)
-                                                        val namespace = generator.config.namespaces[ns]
+                        }
+                        tbody {
+                            enumFields.forEach { field ->
+                                tr {
+                                    td {
+                                        table {
+                                            tbody {
+                                                klass.tree.allNamespaceIds.forEach { id ->
+                                                    val ns = klass.tree.getNamespaceName(id)
+                                                    val namespace = generator.config.namespaces[ns]
 
-                                                        if (namespace != null) {
-                                                            val name = field.getName(id)
-                                                            if (name != null) {
-                                                                tr {
-                                                                    badgeColumnComponent(namespace.friendlyName, namespace.color, styleProvider)
-                                                                    td(classes = "mapping-value") {
-                                                                        +name
-                                                                    }
+                                                    if (namespace != null) {
+                                                        val name = field.getName(id)
+                                                        if (name != null) {
+                                                            tr {
+                                                                badgeColumnComponent(namespace.friendlyName, namespace.color, styleProvider)
+                                                                td(classes = "mapping-value") {
+                                                                    +name
                                                                 }
                                                             }
                                                         }
@@ -241,7 +233,7 @@ fun GenerationContext.classPage(klass: MappingTreeView.ClassMappingView, hash: S
                             fields.forEach { field ->
                                 tr {
                                     td(classes = "modifier-value") {
-                                        +field.modifiers.formatModifiers(fieldMask)
+                                        +field.modifiers.formatModifiers(fieldMask, klassType)
 
                                         unsafe {
                                             +field.formatDescriptor(remapper)
@@ -298,7 +290,7 @@ fun GenerationContext.classPage(klass: MappingTreeView.ClassMappingView, hash: S
                             val ctorMod = ctor.modifiers
                             tr {
                                 td(classes = "modifier-value") {
-                                    +ctorMod.formatModifiers(Modifier.constructorModifiers())
+                                    +ctorMod.formatModifiers(Modifier.constructorModifiers(), klassType)
                                 }
                                 td(classes = "constructor-value") {
                                     unsafe {
@@ -323,7 +315,6 @@ fun GenerationContext.classPage(klass: MappingTreeView.ClassMappingView, hash: S
             // skip constructors and implicit enum methods
             val methods = klass.methods.filter { !it.isConstructor && ((klassDeclaration.modifiers and Opcodes.ACC_ENUM) == 0 || !(it.isEnumValueOf || it.isEnumValues)) }
             if (methods.isNotEmpty()) {
-                val methodMask = Modifier.methodModifiers()
                 val interfaceMethod = (klassDeclaration.modifiers and Opcodes.ACC_INTERFACE) != 0
 
                 addContentSpacer()
@@ -347,7 +338,7 @@ fun GenerationContext.classPage(klass: MappingTreeView.ClassMappingView, hash: S
                             tr {
                                 td(classes = "modifier-value") {
                                     unsafe {
-                                        +methodMod.formatModifiers(methodMask, interfaceMethod)
+                                        +methodMod.formatModifiers(Modifier.methodModifiers(), klassType)
 
                                         val methodDeclaration = method.formatDescriptor(remapper, methodMod)
                                         methodDeclaration.formals?.let { +"$it " }
@@ -430,7 +421,7 @@ fun <T : MappingTreeView.ClassMappingView> T.formatDescriptor(
     val interfaces = this.interfaces
 
     val modifiersAndName = buildString {
-        append(mod.formatModifiers(Modifier.classModifiers()))
+        append(mod.formatModifiers(Modifier.classModifiers(), classTypeOf(mod)))
         when {
             (mod and Opcodes.ACC_ANNOTATION) != 0 -> append("@interface ") // annotations are interfaces, so this must be before ACC_INTERFACE
             (mod and Opcodes.ACC_INTERFACE) != 0 -> {
@@ -633,4 +624,44 @@ fun Type.format(remapper: ContextualElementRemapper, isVarargs: Boolean = false)
         Type.OBJECT, 12 -> remapper.mapAndLink(internalName)
         else -> className
     }
+}
+
+/**
+ * Formats a modifier integer into a string.
+ *
+ * @param mask the modifier mask (you can get that from the [Modifier] class)
+ * @param classType the type of the class or the type of the class containing the member
+ * @return the modifier string, **may end with a space**
+ */
+fun Int.formatModifiers(mask: Int = 0, classType: ClassType): String = buildString {
+    val mMod = this@formatModifiers and mask
+
+    // remove public and abstract modifiers on interface methods, implicit in some cases
+    // see: https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.4
+    if (classType != ClassType.INTERFACE && (mMod and Opcodes.ACC_PUBLIC) != 0) append("public ")
+    if ((mMod and Opcodes.ACC_PRIVATE) != 0) append("private ")
+    if ((mMod and Opcodes.ACC_PROTECTED) != 0) append("protected ")
+    if ((mMod and Opcodes.ACC_STATIC) != 0) append("static ")
+
+    if (classType == ClassType.INTERFACE && (mMod and Opcodes.ACC_ABSTRACT) == 0 && (mMod and Opcodes.ACC_STATIC) == 0 && (mMod and Opcodes.ACC_PUBLIC) != 0) {
+        append("default ")
+    }
+    // enums can have an abstract modifier (methods included) if its constants have a custom impl
+    // TODO: should we remove that?
+
+    // an interface is implicitly abstract
+    // we need to check the unmasked modifiers here, since ACC_INTERFACE is not among Modifier#classModifiers
+    if ((mMod and Opcodes.ACC_ABSTRACT) != 0 && (this@formatModifiers and Opcodes.ACC_INTERFACE) == 0 && classType != ClassType.INTERFACE) append("abstract ")
+    if ((mMod and Opcodes.ACC_FINAL) != 0) {
+        // enums and records are implicitly final
+        // we need to check the unmasked modifiers here, since ACC_ENUM is not among Modifier#classModifiers
+        if (mask != Modifier.classModifiers() || ((this@formatModifiers and Opcodes.ACC_ENUM) == 0 && (this@formatModifiers and Opcodes.ACC_RECORD) == 0)) {
+            append("final ")
+        }
+    }
+    if ((mMod and Opcodes.ACC_NATIVE) != 0) append("native ")
+    if ((mMod and Opcodes.ACC_STRICT) != 0) append("strict ")
+    if ((mMod and Opcodes.ACC_SYNCHRONIZED) != 0) append("synchronized ")
+    if ((mMod and Opcodes.ACC_TRANSIENT) != 0) append("transient ")
+    if ((mMod and Opcodes.ACC_VOLATILE) != 0) append("volatile ")
 }


### PR DESCRIPTION
This PR aims to fix #25 

This PR introduces the `default` modifier for public non-abstract instance method declared in an interface. While this modifier does not exist in the class file, it is used in the source code and in javadoc, and majority of Java developers are familiar with this concept.

This PR also introduced Enum constant summary, which lists enum constants separately from class fields. (similar to Enum Constant Summary in JavaDoc)

![enum constant summary](https://github.com/zlataovce/takenaka/assets/20199703/c41d0941-4bc0-41b8-a787-ead391c37f08)

@zlataovce suggested some alternatives for Enum constant summary:

- Using an arbitrary modifier like `enum-const` and keeping enum constants in the field summary. This way we can still differentiate between enum constants and static final fields referencing an enum constant.
- Removing public static final modifiers for enum constants and keeping them in the field summary.
